### PR TITLE
Use spinlock also for list_replace_rcu()

### DIFF
--- a/list_rcu_example.c
+++ b/list_rcu_example.c
@@ -121,7 +121,10 @@ static int borrow_book(int id, int async) {
 
 	memcpy(new_b, old_b, sizeof(struct book));
 	new_b->borrow = 1;
+	
+	spin_lock(&books_lock);
 	list_replace_rcu(&old_b->node, &new_b->node);
+	spin_unlock(&books_lock);
 
 	rcu_read_unlock();
 
@@ -196,7 +199,10 @@ static int return_book(int id, int async) {
 
 	memcpy(new_b, old_b, sizeof(struct book));
 	new_b->borrow = 0;
+	
+	spin_lock(&books_lock);
 	list_replace_rcu(&old_b->node, &new_b->node);
+	spin_unlock(&books_lock);
 
 	rcu_read_unlock();
 


### PR DESCRIPTION
I'm not a linux expert, so I might be missing something. 
If you don't need the spinlock there, please explain why...

list_replace_rcu() uses rcu_assign_pointer().
The documentation says: 
> „Use rcu_assign_pointer() to update an RCU-protected pointer.
> This primitive protects concurrent readers from the updater,
> -not- concurrent updates from each other!  You therefore still
> need to use locking (or something similar) to keep concurrent
> rcu_assign_pointer() primitives from interfering with each other.“